### PR TITLE
fix: correct Go module path to match GitHub repository

### DIFF
--- a/cmd/dnsmesh/main.go
+++ b/cmd/dnsmesh/main.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/dnsmesh/internal/cluster"
-	"github.com/dnsmesh/internal/config"
-	"github.com/dnsmesh/internal/dns"
-	"github.com/dnsmesh/internal/health"
-	"github.com/dnsmesh/internal/logging"
+	"github.com/tommyskeff/dnsmesh/internal/cluster"
+	"github.com/tommyskeff/dnsmesh/internal/config"
+	"github.com/tommyskeff/dnsmesh/internal/dns"
+	"github.com/tommyskeff/dnsmesh/internal/health"
+	"github.com/tommyskeff/dnsmesh/internal/logging"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dnsmesh
+module github.com/tommyskeff/dnsmesh
 
 go 1.22.0
 

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"fmt"
 
-	"github.com/dnsmesh/internal/config"
+	"github.com/tommyskeff/dnsmesh/internal/config"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )

--- a/internal/cluster/manager.go
+++ b/internal/cluster/manager.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dnsmesh/internal/config"
-	"github.com/dnsmesh/internal/logging"
+	"github.com/tommyskeff/dnsmesh/internal/config"
+	"github.com/tommyskeff/dnsmesh/internal/logging"
 )
 
 const (

--- a/internal/cluster/watcher.go
+++ b/internal/cluster/watcher.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dnsmesh/internal/logging"
+	"github.com/tommyskeff/dnsmesh/internal/logging"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dnsmesh/internal/logging"
+	"github.com/tommyskeff/dnsmesh/internal/logging"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/internal/dns/server.go
+++ b/internal/dns/server.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/dnsmesh/internal/logging"
 	"github.com/miekg/dns"
+	"github.com/tommyskeff/dnsmesh/internal/logging"
 )
 
 type Server struct {

--- a/internal/health/server.go
+++ b/internal/health/server.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"sync/atomic"
 
-	"github.com/dnsmesh/internal/logging"
+	"github.com/tommyskeff/dnsmesh/internal/logging"
 )
 
 type Server struct {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dnsmesh/internal/cluster"
-	"github.com/dnsmesh/internal/dns"
 	mdns "github.com/miekg/dns"
+	"github.com/tommyskeff/dnsmesh/internal/cluster"
+	"github.com/tommyskeff/dnsmesh/internal/dns"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"


### PR DESCRIPTION
## Summary

The Go module path was set to \github.com/dnsmesh\ but the actual repository is at \github.com/tommyskeff/dnsmesh\. This mismatch would prevent the module from being used as a dependency by external Go projects.

## Changes

- Updated \go.mod\ module declaration to \github.com/tommyskeff/dnsmesh\
- Updated all internal import statements across the codebase to use the correct module path

## Testing

- \go build ./...\ succeeds
- \go test ./...\ passes all tests