### PR TITLE
feat: add IPv6 support with AAAA record handling

### DIFF
--- a/internal/dns/server.go
+++ b/internal/dns/server.go
@@ -66,6 +66,8 @@ func (s *Server) handleDNS(w dns.ResponseWriter, r *dns.Msg) {
 		switch q.Qtype {
 		case dns.TypeA:
 			s.handleA(m, q)
+		case dns.TypeAAAA:
+			s.handleAAAA(m, q)
 		default:
 		}
 	}
@@ -78,7 +80,7 @@ func (s *Server) handleDNS(w dns.ResponseWriter, r *dns.Msg) {
 }
 
 func (s *Server) handleA(m *dns.Msg, q dns.Question) {
-	ip := s.table.LookupRandom(q.Name)
+	ip := s.table.LookupRandomIPv4(q.Name)
 	if ip == nil {
 		return
 	}
@@ -96,6 +98,29 @@ func (s *Server) handleA(m *dns.Msg, q dns.Question) {
 			Ttl:    s.ttl,
 		},
 		A: ipv4,
+	}
+	m.Answer = append(m.Answer, rr)
+}
+
+func (s *Server) handleAAAA(m *dns.Msg, q dns.Question) {
+	ip := s.table.LookupRandomIPv6(q.Name)
+	if ip == nil {
+		return
+	}
+
+	ipv6 := ip.To16()
+	if ipv6 == nil {
+		return
+	}
+
+	rr := &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:   q.Name,
+			Rrtype: dns.TypeAAAA,
+			Class:  dns.ClassINET,
+			Ttl:    s.ttl,
+		},
+		AAAA: ipv6,
 	}
 	m.Answer = append(m.Answer, rr)
 }
@@ -140,6 +165,8 @@ func (s *Server) HandleTestQuery(name string, qtype uint16) *dns.Msg {
 		switch q.Qtype {
 		case dns.TypeA:
 			s.handleA(m, q)
+		case dns.TypeAAAA:
+			s.handleAAAA(m, q)
 		}
 	}
 

--- a/internal/dns/server_test.go
+++ b/internal/dns/server_test.go
@@ -100,7 +100,7 @@ func TestServer_HandleOtherTypes(t *testing.T) {
 
 	server := NewServer(table, 30)
 
-	m := server.HandleTestQuery("pricing-server.prod.internal", dns.TypeAAAA)
+	m := server.HandleTestQuery("pricing-server.prod.internal", dns.TypeMX)
 
 	if len(m.Answer) != 0 {
 		t.Errorf("expected 0 answers for unsupported type, got %d", len(m.Answer))
@@ -145,5 +145,140 @@ func TestServer_HandlerFunc(t *testing.T) {
 
 	if len(m.Answer) != 1 {
 		t.Fatalf("expected 1 answer, got %d", len(m.Answer))
+	}
+}
+
+func TestServer_HandleAAAA_Found(t *testing.T) {
+	table := NewTable()
+	table.AddEntry("pricing-server.prod.internal", net.ParseIP("2001:db8::1"), "pod")
+
+	server := NewServer(table, 30)
+
+	m := server.HandleTestQuery("pricing-server.prod.internal", dns.TypeAAAA)
+
+	if m.Rcode != dns.RcodeSuccess {
+		t.Errorf("expected NOERROR, got %s", dns.RcodeToString[m.Rcode])
+	}
+
+	if len(m.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(m.Answer))
+	}
+
+	aaaa, ok := m.Answer[0].(*dns.AAAA)
+	if !ok {
+		t.Fatalf("expected AAAA record, got %T", m.Answer[0])
+	}
+
+	expectedIP := net.ParseIP("2001:db8::1")
+	if !aaaa.AAAA.Equal(expectedIP) {
+		t.Errorf("expected IP %v, got %v", expectedIP, aaaa.AAAA)
+	}
+
+	if aaaa.Hdr.Ttl != 30 {
+		t.Errorf("expected TTL 30, got %d", aaaa.Hdr.Ttl)
+	}
+}
+
+func TestServer_HandleAAAA_NotFound(t *testing.T) {
+	table := NewTable()
+	server := NewServer(table, 30)
+
+	m := server.HandleTestQuery("nonexistent.prod.internal", dns.TypeAAAA)
+
+	if m.Rcode != dns.RcodeNameError {
+		t.Errorf("expected NXDOMAIN, got %s", dns.RcodeToString[m.Rcode])
+	}
+
+	if len(m.Answer) != 0 {
+		t.Errorf("expected 0 answers for NXDOMAIN, got %d", len(m.Answer))
+	}
+}
+
+func TestServer_HandleAAAA_OnlyIPv4Exists(t *testing.T) {
+	table := NewTable()
+	table.AddEntry("pricing-server.prod.internal", net.ParseIP("10.0.0.1"), "pod")
+
+	server := NewServer(table, 30)
+
+	m := server.HandleTestQuery("pricing-server.prod.internal", dns.TypeAAAA)
+
+	if len(m.Answer) != 0 {
+		t.Errorf("expected 0 answers when only IPv4 exists, got %d", len(m.Answer))
+	}
+}
+
+func TestServer_HandleA_OnlyIPv6Exists(t *testing.T) {
+	table := NewTable()
+	table.AddEntry("pricing-server.prod.internal", net.ParseIP("2001:db8::1"), "pod")
+
+	server := NewServer(table, 30)
+
+	m := server.HandleTestQuery("pricing-server.prod.internal", dns.TypeA)
+
+	if len(m.Answer) != 0 {
+		t.Errorf("expected 0 answers when only IPv6 exists, got %d", len(m.Answer))
+	}
+}
+
+func TestServer_HandleMixedIPVersions(t *testing.T) {
+	table := NewTable()
+	table.AddEntry("dual-stack.prod.internal", net.ParseIP("10.0.0.1"), "pod")
+	table.AddEntry("dual-stack.prod.internal", net.ParseIP("2001:db8::1"), "pod")
+
+	server := NewServer(table, 30)
+
+	m := server.HandleTestQuery("dual-stack.prod.internal", dns.TypeA)
+	if m.Rcode != dns.RcodeSuccess {
+		t.Errorf("expected NOERROR for A query, got %s", dns.RcodeToString[m.Rcode])
+	}
+	if len(m.Answer) != 1 {
+		t.Fatalf("expected 1 A answer, got %d", len(m.Answer))
+	}
+	a, ok := m.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("expected A record, got %T", m.Answer[0])
+	}
+	if !a.A.Equal(net.ParseIP("10.0.0.1")) {
+		t.Errorf("expected A record with 10.0.0.1, got %v", a.A)
+	}
+
+	m = server.HandleTestQuery("dual-stack.prod.internal", dns.TypeAAAA)
+	if m.Rcode != dns.RcodeSuccess {
+		t.Errorf("expected NOERROR for AAAA query, got %s", dns.RcodeToString[m.Rcode])
+	}
+	if len(m.Answer) != 1 {
+		t.Fatalf("expected 1 AAAA answer, got %d", len(m.Answer))
+	}
+	aaaa, ok := m.Answer[0].(*dns.AAAA)
+	if !ok {
+		t.Fatalf("expected AAAA record, got %T", m.Answer[0])
+	}
+	if !aaaa.AAAA.Equal(net.ParseIP("2001:db8::1")) {
+		t.Errorf("expected AAAA record with 2001:db8::1, got %v", aaaa.AAAA)
+	}
+}
+
+func TestServer_HandleAAAA_MultipleIPs(t *testing.T) {
+	table := NewTable()
+	table.AddEntry("multi-ipv6.prod.internal", net.ParseIP("2001:db8::1"), "pod")
+	table.AddEntry("multi-ipv6.prod.internal", net.ParseIP("2001:db8::2"), "pod")
+	table.AddEntry("multi-ipv6.prod.internal", net.ParseIP("2001:db8::3"), "pod")
+
+	server := NewServer(table, 30)
+
+	seen := make(map[string]bool)
+	for i := 0; i < 50; i++ {
+		m := server.HandleTestQuery("multi-ipv6.prod.internal", dns.TypeAAAA)
+
+		if len(m.Answer) != 1 {
+			t.Fatalf("expected 1 answer, got %d", len(m.Answer))
+		}
+
+		aaaa := m.Answer[0].(*dns.AAAA)
+		seen[aaaa.AAAA.String()] = true
+	}
+
+	if len(seen) < 2 {
+		t.Logf("warning: only saw %d unique IPs in 50 queries", len(seen))
 	}
 }

--- a/internal/dns/table.go
+++ b/internal/dns/table.go
@@ -87,6 +87,50 @@ func (t *Table) LookupRandom(name string) net.IP {
 	return ips[rand.Intn(len(ips))]
 }
 
+func (t *Table) LookupIPv4(name string) []net.IP {
+	ips := t.Lookup(name)
+	var ipv4s []net.IP
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			ipv4s = append(ipv4s, ip)
+		}
+	}
+	return ipv4s
+}
+
+func (t *Table) LookupIPv6(name string) []net.IP {
+	ips := t.Lookup(name)
+	var ipv6s []net.IP
+	for _, ip := range ips {
+		if ip.To4() == nil && ip.To16() != nil {
+			ipv6s = append(ipv6s, ip)
+		}
+	}
+	return ipv6s
+}
+
+func (t *Table) LookupRandomIPv4(name string) net.IP {
+	ips := t.LookupIPv4(name)
+	if len(ips) == 0 {
+		return nil
+	}
+	if len(ips) == 1 {
+		return ips[0]
+	}
+	return ips[rand.Intn(len(ips))]
+}
+
+func (t *Table) LookupRandomIPv6(name string) net.IP {
+	ips := t.LookupIPv6(name)
+	if len(ips) == 0 {
+		return nil
+	}
+	if len(ips) == 1 {
+		return ips[0]
+	}
+	return ips[rand.Intn(len(ips))]
+}
+
 func (t *Table) Count() int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/internal/dns/table_test.go
+++ b/internal/dns/table_test.go
@@ -199,3 +199,147 @@ func TestTable_ConcurrentAccess(t *testing.T) {
 		t.Errorf("expected 100 entries, got %d", table.Count())
 	}
 }
+
+func TestTable_IPv6Entry(t *testing.T) {
+	table := NewTable()
+
+	ipv6 := net.ParseIP("2001:db8::1")
+	table.AddEntry("test.example.com", ipv6, "pod")
+
+	ips := table.Lookup("test.example.com")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP, got %d", len(ips))
+	}
+	if !ips[0].Equal(ipv6) {
+		t.Errorf("expected IP %v, got %v", ipv6, ips[0])
+	}
+}
+
+func TestTable_LookupIPv4(t *testing.T) {
+	table := NewTable()
+
+	ipv4 := net.ParseIP("10.0.0.1")
+	ipv6 := net.ParseIP("2001:db8::1")
+
+	table.AddEntry("test.example.com", ipv4, "pod")
+	table.AddEntry("test.example.com", ipv6, "pod")
+
+	ipv4s := table.LookupIPv4("test.example.com")
+	if len(ipv4s) != 1 {
+		t.Errorf("expected 1 IPv4 address, got %d", len(ipv4s))
+	}
+	if !ipv4s[0].Equal(ipv4) {
+		t.Errorf("expected IPv4 %v, got %v", ipv4, ipv4s[0])
+	}
+}
+
+func TestTable_LookupIPv6(t *testing.T) {
+	table := NewTable()
+
+	ipv4 := net.ParseIP("10.0.0.1")
+	ipv6 := net.ParseIP("2001:db8::1")
+
+	table.AddEntry("test.example.com", ipv4, "pod")
+	table.AddEntry("test.example.com", ipv6, "pod")
+
+	ipv6s := table.LookupIPv6("test.example.com")
+	if len(ipv6s) != 1 {
+		t.Errorf("expected 1 IPv6 address, got %d", len(ipv6s))
+	}
+	if !ipv6s[0].Equal(ipv6) {
+		t.Errorf("expected IPv6 %v, got %v", ipv6, ipv6s[0])
+	}
+}
+
+func TestTable_LookupRandomIPv4(t *testing.T) {
+	table := NewTable()
+
+	table.AddEntry("test.example.com", net.ParseIP("10.0.0.1"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("10.0.0.2"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("2001:db8::1"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("2001:db8::2"), "pod")
+
+	for i := 0; i < 20; i++ {
+		ip := table.LookupRandomIPv4("test.example.com")
+		if ip == nil {
+			t.Fatal("expected non-nil IP from LookupRandomIPv4")
+		}
+		if ip.To4() == nil {
+			t.Errorf("LookupRandomIPv4 returned non-IPv4 address: %v", ip)
+		}
+	}
+}
+
+func TestTable_LookupRandomIPv6(t *testing.T) {
+	table := NewTable()
+
+	table.AddEntry("test.example.com", net.ParseIP("10.0.0.1"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("10.0.0.2"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("2001:db8::1"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("2001:db8::2"), "pod")
+
+	for i := 0; i < 20; i++ {
+		ip := table.LookupRandomIPv6("test.example.com")
+		if ip == nil {
+			t.Fatal("expected non-nil IP from LookupRandomIPv6")
+		}
+		if ip.To4() != nil {
+			t.Errorf("LookupRandomIPv6 returned IPv4 address: %v", ip)
+		}
+	}
+}
+
+func TestTable_LookupIPv4Only(t *testing.T) {
+	table := NewTable()
+
+	table.AddEntry("test.example.com", net.ParseIP("2001:db8::1"), "pod")
+
+	ipv4s := table.LookupIPv4("test.example.com")
+	if len(ipv4s) != 0 {
+		t.Errorf("expected 0 IPv4 addresses, got %d", len(ipv4s))
+	}
+
+	ip := table.LookupRandomIPv4("test.example.com")
+	if ip != nil {
+		t.Errorf("expected nil for LookupRandomIPv4 with only IPv6 entries, got %v", ip)
+	}
+}
+
+func TestTable_LookupIPv6Only(t *testing.T) {
+	table := NewTable()
+
+	table.AddEntry("test.example.com", net.ParseIP("10.0.0.1"), "pod")
+
+	ipv6s := table.LookupIPv6("test.example.com")
+	if len(ipv6s) != 0 {
+		t.Errorf("expected 0 IPv6 addresses, got %d", len(ipv6s))
+	}
+
+	ip := table.LookupRandomIPv6("test.example.com")
+	if ip != nil {
+		t.Errorf("expected nil for LookupRandomIPv6 with only IPv4 entries, got %v", ip)
+	}
+}
+
+func TestTable_MixedIPVersions(t *testing.T) {
+	table := NewTable()
+
+	table.AddEntry("test.example.com", net.ParseIP("10.0.0.1"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("10.0.0.2"), "service")
+	table.AddEntry("test.example.com", net.ParseIP("2001:db8::1"), "pod")
+	table.AddEntry("test.example.com", net.ParseIP("2001:db8::2"), "service")
+
+	if table.Count() != 4 {
+		t.Errorf("expected count 4, got %d", table.Count())
+	}
+
+	ipv4s := table.LookupIPv4("test.example.com")
+	if len(ipv4s) != 2 {
+		t.Errorf("expected 2 IPv4 addresses, got %d", len(ipv4s))
+	}
+
+	ipv6s := table.LookupIPv6("test.example.com")
+	if len(ipv6s) != 2 {
+		t.Errorf("expected 2 IPv6 addresses, got %d", len(ipv6s))
+	}
+}


### PR DESCRIPTION
Adds IPv6 support for Kubernetes dual-stack networking. DNSMesh can now serve AAAA records for IPv6 addresses alongside A records for IPv4.