### PR TITLE
fix(chart): remove unnecessary secret volume mount

### DIFF
--- a/charts/dnsmesh/templates/deployment.yaml
+++ b/charts/dnsmesh/templates/deployment.yaml
@@ -76,14 +76,6 @@ spec:
             timeoutSeconds: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-            - name: config-secret
-              mountPath: /etc/dnsmesh
-              readOnly: true
-      volumes:
-        - name: config-secret
-          secret:
-            secretName: {{ include "dnsmesh.globalConfigSecretName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The config secret is read directly via the Kubernetes API using the service account, not from a mounted file. The volume mount was unused and added unnecessary coupling.