### PR TITLE
feat: add placeholder support for service and realm annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Example: `nginx-test.prod-na.clusterset.local`
 
 - **Multi-cluster support** - Watch resources across multiple Kubernetes clusters
 - **Annotation-based discovery** - Opt-in via `dnsmesh.tommyjs.dev/expose: "true"`
+- **Dynamic placeholders** - Use `{name}`, `{ordinal}`, `{namespace}`, etc. in annotations
+- **IPv4 and IPv6 support** - Serves both A and AAAA records
 - **Random load balancing** - Multiple IPs for the same name are returned randomly
 - **Configurable TTL** - Control DNS caching behavior
 - **Health endpoints** - `/healthz` and `/readyz` for Kubernetes probes
@@ -79,6 +81,61 @@ annotations:
 ```
 
 This creates DNS records like `my-app.prod-na.clusterset.local`.
+
+### Annotation Placeholders
+
+The `service` and `realm` annotations support dynamic placeholders that are resolved at runtime:
+
+| Placeholder | Description | Example Value |
+|-------------|-------------|---------------|
+| `{name}` | Name of the pod or service | `redis-cluster-0` |
+| `{ip}` | IP address in dash form | `10-0-0-1` |
+| `{ordinal}` | StatefulSet pod ordinal (empty for non-StatefulSet pods/services) | `0`, `1`, `2` |
+| `{namespace}` | Kubernetes namespace | `production` |
+| `{kind}` | Resource type | `pod` or `service` |
+| `{node}` | Node name (empty for services) | `node-1` |
+
+#### Examples
+
+**StatefulSet with per-pod DNS names:**
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  template:
+    metadata:
+      annotations:
+        dnsmesh.tommyjs.dev/expose: "true"
+        dnsmesh.tommyjs.dev/service: "redis-{ordinal}"
+        dnsmesh.tommyjs.dev/realm: "prod"
+```
+
+This creates DNS records like `redis-0.prod.clusterset.local`, `redis-1.prod.clusterset.local`, etc.
+
+**Namespace-based realm:**
+
+```yaml
+annotations:
+  dnsmesh.tommyjs.dev/expose: "true"
+  dnsmesh.tommyjs.dev/service: "my-app"
+  dnsmesh.tommyjs.dev/realm: "{namespace}"
+```
+
+This creates DNS records using the Kubernetes namespace as the realm, e.g., `my-app.production.clusterset.local`.
+
+**Combined placeholders:**
+
+```yaml
+annotations:
+  dnsmesh.tommyjs.dev/expose: "true"
+  dnsmesh.tommyjs.dev/service: "{namespace}-{name}"
+  dnsmesh.tommyjs.dev/realm: "{kind}"
+```
+
+This creates DNS records like `production-my-app-0.pod.clusterset.local`.
 
 ### CoreDNS Configuration
 

--- a/cmd/dnsmesh/main.go
+++ b/cmd/dnsmesh/main.go
@@ -49,13 +49,11 @@ func main() {
 		logging.Info("Configuration loaded: %d clusters", len(cfg.Clusters))
 
 		if initialStartup {
-			// First load - just create the manager, InitialConnect will be called after
 			dnsTable.Clear()
 			clusterManager = cluster.NewManager(domain, dnsTable)
 			return
 		}
 
-		// Subsequent config changes - update clusters
 		if clusterManager != nil {
 			clusterManager.Stop()
 		}

--- a/internal/cluster/watcher.go
+++ b/internal/cluster/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -204,6 +205,10 @@ func (w *Watcher) processPod(pod *corev1.Pod) {
 		return
 	}
 
+	placeholders := w.buildPodPlaceholders(pod)
+	serviceName = resolvePlaceholders(serviceName, placeholders)
+	realm = resolvePlaceholders(realm, placeholders)
+
 	dnsName := w.buildDNSName(serviceName, realm)
 	entry := DNSEntry{
 		Name:   dnsName,
@@ -264,6 +269,10 @@ func (w *Watcher) processService(svc *corev1.Service) {
 		return
 	}
 
+	placeholders := w.buildServicePlaceholders(svc)
+	serviceName = resolvePlaceholders(serviceName, placeholders)
+	realm = resolvePlaceholders(realm, placeholders)
+
 	dnsName := w.buildDNSName(serviceName, realm)
 	entry := DNSEntry{
 		Name:   dnsName,
@@ -305,4 +314,45 @@ func (w *Watcher) buildDNSName(serviceName, realm string) string {
 		name += "."
 	}
 	return name
+}
+
+var statefulSetOrdinalRegex = regexp.MustCompile(`-([0-9]+)$`)
+
+func (w *Watcher) buildPodPlaceholders(pod *corev1.Pod) map[string]string {
+	ordinal := ""
+	if matches := statefulSetOrdinalRegex.FindStringSubmatch(pod.Name); len(matches) == 2 {
+		ordinal = matches[1]
+	}
+
+	return map[string]string{
+		"name":      pod.Name,
+		"ip":        ipToDashForm(pod.Status.PodIP),
+		"ordinal":   ordinal,
+		"namespace": pod.Namespace,
+		"kind":      "pod",
+		"node":      pod.Spec.NodeName,
+	}
+}
+
+func (w *Watcher) buildServicePlaceholders(svc *corev1.Service) map[string]string {
+	return map[string]string{
+		"name":      svc.Name,
+		"ip":        ipToDashForm(svc.Spec.ClusterIP),
+		"ordinal":   "",
+		"namespace": svc.Namespace,
+		"kind":      "service",
+		"node":      "",
+	}
+}
+
+func resolvePlaceholders(template string, placeholders map[string]string) string {
+	result := template
+	for key, value := range placeholders {
+		result = strings.ReplaceAll(result, "{" + key + "}", value)
+	}
+	return result
+}
+
+func ipToDashForm(ip string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(ip, ".", "-"), ":", "-")
 }

--- a/internal/cluster/watcher_test.go
+++ b/internal/cluster/watcher_test.go
@@ -451,3 +451,381 @@ func TestWatcher_DeletePod(t *testing.T) {
 		t.Error("expected entry to be removed after delete")
 	}
 }
+
+func TestResolvePlaceholders(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     string
+		placeholders map[string]string
+		expected     string
+	}{
+		{
+			name:     "no placeholders",
+			template: "my-service",
+			placeholders: map[string]string{
+				"name": "my-pod",
+			},
+			expected: "my-service",
+		},
+		{
+			name:     "single placeholder",
+			template: "{name}",
+			placeholders: map[string]string{
+				"name": "my-pod",
+			},
+			expected: "my-pod",
+		},
+		{
+			name:     "multiple placeholders",
+			template: "{name}-{namespace}",
+			placeholders: map[string]string{
+				"name":      "my-pod",
+				"namespace": "default",
+			},
+			expected: "my-pod-default",
+		},
+		{
+			name:     "placeholder with surrounding text",
+			template: "service-{ordinal}-{namespace}",
+			placeholders: map[string]string{
+				"ordinal":   "2",
+				"namespace": "prod",
+			},
+			expected: "service-2-prod",
+		},
+		{
+			name:     "empty placeholder value",
+			template: "service-{ordinal}",
+			placeholders: map[string]string{
+				"ordinal": "",
+			},
+			expected: "service-",
+		},
+		{
+			name:     "unknown placeholder left as-is",
+			template: "{unknown}",
+			placeholders: map[string]string{
+				"name": "my-pod",
+			},
+			expected: "{unknown}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolvePlaceholders(tt.template, tt.placeholders)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIpToDashForm(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"10.0.0.1", "10-0-0-1"},
+		{"192.168.1.100", "192-168-1-100"},
+		{"2001:db8::1", "2001-db8--1"},
+		{"::1", "--1"},
+	}
+
+	for _, tt := range tests {
+		result := ipToDashForm(tt.input)
+		if result != tt.expected {
+			t.Errorf("ipToDashForm(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestWatcher_PlaceholderInServiceAnnotation(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	updater := newMockUpdater()
+	watcher := NewWatcher("test-cluster", client, "clusterset.local", updater)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start watcher: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app-0",
+			Namespace: "production",
+			UID:       "pod-uid-placeholder-1",
+			Annotations: map[string]string{
+				AnnotationExpose:  "true",
+				AnnotationService: "{name}",
+				AnnotationRealm:   "prod",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.1",
+		},
+	}
+
+	_, err := client.CoreV1().Pods("production").Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ips := updater.getIPs("my-app-0.prod.clusterset.local.")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP for {name} placeholder, got %d (entries: %v)", len(ips), updater.entries)
+	}
+}
+
+func TestWatcher_PlaceholderInRealmAnnotation(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	updater := newMockUpdater()
+	watcher := NewWatcher("test-cluster", client, "clusterset.local", updater)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start watcher: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app-0",
+			Namespace: "production",
+			UID:       "pod-uid-placeholder-2",
+			Annotations: map[string]string{
+				AnnotationExpose:  "true",
+				AnnotationService: "my-app",
+				AnnotationRealm:   "{namespace}",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.2",
+		},
+	}
+
+	_, err := client.CoreV1().Pods("production").Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ips := updater.getIPs("my-app.production.clusterset.local.")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP for {namespace} placeholder, got %d (entries: %v)", len(ips), updater.entries)
+	}
+}
+
+func TestWatcher_StatefulSetOrdinalPlaceholder(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	updater := newMockUpdater()
+	watcher := NewWatcher("test-cluster", client, "clusterset.local", updater)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start watcher: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis-cluster-2",
+			Namespace: "default",
+			UID:       "pod-uid-sts-ordinal",
+			Annotations: map[string]string{
+				AnnotationExpose:  "true",
+				AnnotationService: "redis-{ordinal}",
+				AnnotationRealm:   "prod",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.3",
+		},
+	}
+
+	_, err := client.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ips := updater.getIPs("redis-2.prod.clusterset.local.")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP for {ordinal} placeholder, got %d (entries: %v)", len(ips), updater.entries)
+	}
+}
+
+func TestWatcher_IpPlaceholder(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	updater := newMockUpdater()
+	watcher := NewWatcher("test-cluster", client, "clusterset.local", updater)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start watcher: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-server-0",
+			Namespace: "default",
+			UID:       "pod-uid-ip-placeholder",
+			Annotations: map[string]string{
+				AnnotationExpose:  "true",
+				AnnotationService: "web-{ip}",
+				AnnotationRealm:   "prod",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.4",
+		},
+	}
+
+	_, err := client.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ips := updater.getIPs("web-10-0-0-4.prod.clusterset.local.")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP for {ip} placeholder, got %d (entries: %v)", len(ips), updater.entries)
+	}
+}
+
+func TestWatcher_KindPlaceholder(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	updater := newMockUpdater()
+	watcher := NewWatcher("test-cluster", client, "clusterset.local", updater)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start watcher: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "default",
+			UID:       "pod-uid-kind",
+			Annotations: map[string]string{
+				AnnotationExpose:  "true",
+				AnnotationService: "my-app",
+				AnnotationRealm:   "{kind}",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.5",
+		},
+	}
+
+	_, err := client.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ips := updater.getIPs("my-app.pod.clusterset.local.")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP for {kind} placeholder on pod, got %d (entries: %v)", len(ips), updater.entries)
+	}
+}
+
+func TestWatcher_ServicePlaceholders(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	updater := newMockUpdater()
+	watcher := NewWatcher("test-cluster", client, "clusterset.local", updater)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start watcher: %v", err)
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-gateway",
+			Namespace: "prod-namespace",
+			UID:       "svc-uid-placeholder",
+			Annotations: map[string]string{
+				AnnotationExpose:  "true",
+				AnnotationService: "{name}",
+				AnnotationRealm:   "{namespace}-{kind}",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.100.0.5",
+		},
+	}
+
+	_, err := client.CoreV1().Services("prod-namespace").Create(ctx, svc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ips := updater.getIPs("api-gateway.prod-namespace-service.clusterset.local.")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP for service placeholders, got %d (entries: %v)", len(ips), updater.entries)
+	}
+}
+
+func TestWatcher_MultiplePlaceholders(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	updater := newMockUpdater()
+	watcher := NewWatcher("test-cluster", client, "clusterset.local", updater)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("failed to start watcher: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis-cluster-1",
+			Namespace: "cache",
+			UID:       "pod-uid-multi",
+			Annotations: map[string]string{
+				AnnotationExpose:  "true",
+				AnnotationService: "{namespace}-redis-{ordinal}",
+				AnnotationRealm:   "{kind}-realm",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.10",
+		},
+	}
+
+	_, err := client.CoreV1().Pods("cache").Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create pod: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	ips := updater.getIPs("cache-redis-1.pod-realm.clusterset.local.")
+	if len(ips) != 1 {
+		t.Errorf("expected 1 IP for multiple placeholders, got %d (entries: %v)", len(ips), updater.entries)
+	}
+}


### PR DESCRIPTION
Adds dynamic placeholder resolution for the \service\ and \ealm\ annotations, allowing values to be computed at runtime based on resource metadata.

## Supported Placeholders

| Placeholder | Description | Example |
|-------------|-------------|---------|
| \{name}\ | Name of pod/service | \edis-cluster-0\ |
| \{ip}\ | IP in dash form | \10-0-0-1\ |
| \{ordinal}\ | StatefulSet ordinal | \